### PR TITLE
Adding forward slash support in namespace name. 

### DIFF
--- a/src/Storage.as
+++ b/src/Storage.as
@@ -1,4 +1,4 @@
-﻿﻿/**
+/**
  * SwfStore - a JavaScript library for cross-domain flash cookies
  *
  * http://github.com/nfriedly/Javascript-Flash-Cookies
@@ -49,7 +49,7 @@ package {
 		/**
 		 * Namespace portion provided by JS is tested against this to avoid XSS
 		 */
-		private var namespaceCheck:RegExp = /^[a-z0-9_]+$/i;
+		private var namespaceCheck:RegExp = /^[a-z0-9_\/]+$/i;
 
 		/**
 		 * Text field used by local logging
@@ -92,7 +92,6 @@ package {
 			// More information: http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/system/Security.html#allowDomain%28%29
 			Security.allowDomain("*");
 			Security.allowInsecureDomain("*");
-
 
 			// try to initialize our lso
 			try{

--- a/src/swfstore.js
+++ b/src/swfstore.js
@@ -33,7 +33,7 @@
 
     var counter = 0; // a counter for element id's and whatnot
 
-    var alpnum = /[^a-z0-9_]/ig; //a regex to find anything thats not letters and numbers
+    var alpnum = /[^a-z0-9_\/]/ig; //a regex to find anything thats not letters and numbers
 
     /**
      * SwfStore constructor - creates a new SwfStore object and embeds the .swf into the web page.
@@ -87,7 +87,7 @@
 
         // a couple of basic timesaver functions
         function id() {
-            return "SwfStore_" + config.namespace + "_" + (counter++);
+            return "SwfStore_" + config.namespace.replace("/", "_") + "_" + (counter++);
         }
 
         function div(visible) {
@@ -139,7 +139,7 @@
 
         var swfName = id();
 
-        var flashvars = "namespace=" + config.namespace;
+        var flashvars = "namespace=" + encodeURIComponent(config.namespace);
 
 
         swfContainer.innerHTML = '<object height="100" width="500" codebase="https://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab" id="' +


### PR DESCRIPTION
Forward slash is supported character in namespace name, see: http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/SharedObject.html#getLocal()
