### PR TITLE
Adding forward slash support in namespace name

### DIFF
--- a/src/Storage.as
+++ b/src/Storage.as
@@ -80,7 +80,7 @@ package {
 			// since even logging involves communicating with javascript,
 			// the next thing to do is find the external log function
 			if(this.loaderInfo.parameters.namespace) {
-				jsNamespace = "SwfStore." + this.loaderInfo.parameters.namespace + ".";
+				jsNamespace = "SwfStore." + this.loaderInfo.parameters.namespace.replace("/", "_") + ".";
 			}
 
 			log('Initializing...');

--- a/src/swfstore.js
+++ b/src/swfstore.js
@@ -33,7 +33,7 @@
 
     var counter = 0; // a counter for element id's and whatnot
 
-    var alpnum = /[^a-z0-9_\/]/ig; //a regex to find anything thats not letters and numbers
+    var alpnum = /[^a-z0-9_\/]/ig; //a regex to find anything thats not letters, numbers underscore and forward slash
 
     /**
      * SwfStore constructor - creates a new SwfStore object and embeds the .swf into the web page.
@@ -133,7 +133,7 @@
         this.log('info', 'js', 'Initializing...');
 
         // the callback functions that javascript provides to flash must be globally accessible
-        SwfStore[config.namespace] = this;
+        SwfStore[config.namespace.replace("/", "_")] = this;
 
         var swfContainer = div(config.debug);
 


### PR DESCRIPTION
Forward slash is supported character in namespace name, see: http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/SharedObject.html#getLocal()

New pull request based on comments in #27
