### PR TITLE
Make debug switchable on the fly

### DIFF
--- a/src/swfstore.js
+++ b/src/swfstore.js
@@ -103,32 +103,31 @@
             return d;
         }
 
-        // get a logger ready if appropriate
-        if (config.debug) {
-            // if we're in a browser that doesn't have a console, build one
-            if (typeof console === "undefined") {
-                var loggerOutput = div(true);
-                this.console = {
-                    log: function(msg) {
-                        var m = div(true);
-                        m.innerHTML = msg;
-                        loggerOutput.appendChild(m);
-                    }
-                };
-            } else {
-                this.console = console;
-            }
-            this.log = function(type, source, msg) {
-                source = (source === 'swfStore') ? 'swf' : source;
-                if (typeof(this.console[type]) !== "undefined") {
-                    this.console[type]('SwfStore - ' + config.namespace + ' (' + source + '): ' + msg);
-                } else {
-                    this.console.log('SwfStore - ' + config.namespace + ": " + type + ' (' + source + '): ' + msg);
-                }
-            };
-        } else {
-            this.log = function() {}; // if we're not in debug, then we don't need to log anything
-        }
+		// get a logger ready
+		// if we're in a browser that doesn't have a console, build one
+		if (typeof console === "undefined") {
+			var loggerOutput = div(true);
+			this.console = {
+				log: function(msg) {
+					var m = div(true);
+					m.innerHTML = msg;
+					loggerOutput.appendChild(m);
+				}
+			};
+		} else {
+			this.console = console;
+		}
+		this.log = function(type, source, msg) {
+			if (config.debug) {
+				// only output to log if debug is currently enabled
+				source = (source === 'swfStore') ? 'swf' : source;
+				if (typeof(this.console[type]) !== "undefined") {
+					this.console[type]('SwfStore - ' + config.namespace + ' (' + source + '): ' + msg);
+				} else {
+					this.console.log('SwfStore - ' + config.namespace + ": " + type + ' (' + source + '): ' + msg);
+				}
+			}
+		};
 
         this.log('info', 'js', 'Initializing...');
 


### PR DESCRIPTION
Instead of choosing between a "real" and a "dummy" function at creation time based on debug switch, always use the "real" function that only does stuff if debug is on.

This way you'd be able to enable or disable logging without having to recreate the SwfStore object. Changing debug after creation still won't affect position of the div with flash plugin or logger, however. But it can always be done via js should the need arise, while recreating the whole SwfStore might be troublesome.

I'm not sure what would happen when the browser doesn't have console though.